### PR TITLE
Create a 0repo-compatible configuration by default

### DIFF
--- a/0release
+++ b/0release
@@ -2,7 +2,10 @@
 # Copyright (C) 2009, Thomas Leonard
 # See the README file for details, or visit http://0install.net.
 
-from optparse import OptionParser
+#import coverage
+#coverage.process_startup()
+
+from optparse import OptionParser, SUPPRESS_HELP
 import os, sys
 
 zi = os.environ.get("ZI_RELEASE_ZEROINSTALL", None)
@@ -24,10 +27,10 @@ parser.add_option("", "--build-slave", help="compile a binary a source release c
 parser.add_option("-k", "--key", help="GPG key to use for signing", action='store', metavar='KEYID')
 parser.add_option("-v", "--verbose", help="more verbose output", action='count')
 parser.add_option("-r", "--release", help="make a new release", action='store_true')
-parser.add_option("", "--archive-dir-public-url", help="remote directory for releases", metavar='URL')
-parser.add_option("", "--master-feed-file", help="local file to extend with new releases", metavar='PATH')
-parser.add_option("", "--archive-upload-command", help="shell command to upload releases", metavar='COMMAND')
-parser.add_option("", "--master-feed-upload-command", help="shell command to upload feed", metavar='COMMAND')
+parser.add_option("", "--archive-dir-public-url", help=SUPPRESS_HELP, metavar='URL')
+parser.add_option("", "--master-feed-file", help=SUPPRESS_HELP, metavar='PATH')
+parser.add_option("", "--archive-upload-command", help=SUPPRESS_HELP, metavar='COMMAND')
+parser.add_option("", "--master-feed-upload-command", help=SUPPRESS_HELP, metavar='COMMAND')
 parser.add_option("", "--public-scm-repository", help="the name of the repository to push to", metavar='REPOS')
 parser.add_option("", "--release-version", help="explicitly set the version of this release", metavar='VERSION')
 parser.add_option("-V", "--version", help="display version information", action='store_true')

--- a/compile.py
+++ b/compile.py
@@ -12,7 +12,6 @@ class Compiler:
 	def __init__(self, options, src_feed_name, release_version):
 		self.src_feed_name = src_feed_name
 		self.src_feed = support.load_feed(src_feed_name)
-		self.archive_dir_public_url = support.get_archive_url(options, release_version, '')
 
 		self.config = ConfigParser.RawConfigParser()
 
@@ -68,7 +67,7 @@ class Compiler:
 
 				if start: support.show_and_run(start, [])
 				try:
-					args = [os.path.basename(self.src_feed_name), archive_file, self.archive_dir_public_url, binary_feed + '.new']
+					args = [os.path.basename(self.src_feed_name), archive_file, '', binary_feed + '.new']
 					if not command:
 						assert target == 'host', 'Missing build command'
 						support.check_call([sys.executable, sys.argv[0], '--build-slave'] + args)
@@ -98,6 +97,7 @@ class Compiler:
 
 # This is the actual build process, running on the build machine
 def build_slave(src_feed, archive_file, archive_dir_public_url, target_feed):
+	if archive_dir_public_url: print "WARNING: archive_dir_public_url is deprecated!"
 	try:
 		COMPILE = [os.environ['ZI_COMPILE']]
 	except KeyError:

--- a/release.py
+++ b/release.py
@@ -224,7 +224,11 @@ def do_release(local_feed, options):
 		support.make_archives_relative(new_impls_feed)
 		oldcwd = os.getcwd()
 		try:
-			repo.cmd.main(['0repo', 'add', '--', new_impls_feed])
+			cmd = ['0repo', 'add', '--', new_impls_feed]
+			print "Handing off to 0repo:"
+			print " ".join(cmd)
+			print ""
+			repo.cmd.main(cmd)
 		finally:
 			os.chdir(oldcwd)
 

--- a/setup.py
+++ b/setup.py
@@ -22,42 +22,15 @@ def init_releases_directory(feed):
 		make_release = file('make-release.bat', 'w')
 		make_release.write("""@echo off
 
-:: The directory people will download the releases from.
-:: This will appear in the remote feed file.
-::set ARCHIVE_DIR_PUBLIC_URL=http://placeholder.org/releases/%%RELEASE_VERSION%%
-set ARCHIVE_DIR_PUBLIC_URL=
-
-:: The path to the main feed.
-:: The new version is added here when you publish a release.
-::set MASTER_FEED_FILE="$HOME/public_html/feeds/MyProg.xml"
-set MASTER_FEED_FILE=%s
-
-:: A shell command to upload the generated archive file to the
-:: public server (corresponds to %%ARCHIVE_DIR_PUBLIC_URL%%, which is
-:: used to download it again).
-:: If unset, you'll have to upload it yourself.
-::set ARCHIVE_UPLOAD_COMMAND=scp %%* me@myhost:/var/www/releases/%%RELEASE_VERSION%%/
-set ARCHIVE_UPLOAD_COMMAND=
-
-:: A shell command to upload the master feed (%%MASTER_FEED_FILE%%) and
-:: related files to your web server. It will be downloaded using the
-:: feed's URL. If unset, you'll have to upload it yourself.
-::set MASTER_FEED_UPLOAD_COMMAND=scp %%* me@myhost:/var/www/feeds/
-set MASTER_FEED_UPLOAD_COMMAND=
-
 :: Your public version control repository. When publishing, the new
 :: HEAD and the release tag will be pushed to this using a command
-:: such as "git-push main master v0.1"
+:: such as "git push origin master v0.1"
 :: If unset, you'll have to update it yourself.
 ::set PUBLIC_SCM_REPOSITORY=origin
 set PUBLIC_SCM_REPOSITORY=
 
 cd /d "%%~dp0"
 0launch %s --release %s ^
- --archive-dir-public-url="%%ARCHIVE_DIR_PUBLIC_URL%%" ^
- --master-feed-file="%%MASTER_FEED_FILE%%" ^
- --archive-upload-command="%%ARCHIVE_UPLOAD_COMMAND%%" ^
- --master-feed-upload-command="%%MASTER_FEED_UPLOAD_COMMAND%%" ^
  --public-scm-repository="%%PUBLIC_SCM_REPOSITORY%%" ^
  %%*
 """ % (master_feed_name, release_uri, feed.local_path))
@@ -67,45 +40,19 @@ cd /d "%%~dp0"
 		make_release = file('make-release', 'w')
 		make_release.write("""#!/bin/sh
 
-# The directory people will download the releases from.
-# This will appear in the remote feed file.
-#ARCHIVE_DIR_PUBLIC_URL='http://placeholder.org/releases/$RELEASE_VERSION'
-ARCHIVE_DIR_PUBLIC_URL=
-
-# The path to the main feed.
-# The new version is added here when you publish a release.
-#MASTER_FEED_FILE="$HOME/public_html/feeds/MyProg.xml"
-MASTER_FEED_FILE="%s"
-
-# A shell command to upload the generated archive file to the
-# public server (corresponds to $ARCHIVE_DIR_PUBLIC_URL, which is
-# used to download it again).
-# If unset, you'll have to upload it yourself.
-#ARCHIVE_UPLOAD_COMMAND='scp "$@" me@myhost:/var/www/releases/$RELEASE_VERSION/'
-ARCHIVE_UPLOAD_COMMAND=
-
-# A shell command to upload the master feed ($MASTER_FEED_FILE) and
-# related files to your web server. It will be downloaded using the
-# feed's URL. If unset, you'll have to upload it yourself.
-#MASTER_FEED_UPLOAD_COMMAND='scp "$@" me@myhost:/var/www/feeds/'
-MASTER_FEED_UPLOAD_COMMAND=
-
 # Your public version control repository. When publishing, the new
 # HEAD and the release tag will be pushed to this using a command
-# such as "git-push main master v0.1"
+# such as "git push origin master v0.1"
 # If unset, you'll have to update it yourself.
 #PUBLIC_SCM_REPOSITORY=origin
 PUBLIC_SCM_REPOSITORY=
 
 cd `dirname "$0"`
-exec 0launch %s --release %s \\
- --archive-dir-public-url="$ARCHIVE_DIR_PUBLIC_URL" \\
- --master-feed-file="$MASTER_FEED_FILE" \\
- --archive-upload-command="$ARCHIVE_UPLOAD_COMMAND" \\
- --master-feed-upload-command="$MASTER_FEED_UPLOAD_COMMAND" \\
+exec 0launch %s \\
+ --release %s \\
  --public-scm-repository="$PUBLIC_SCM_REPOSITORY" \\
  "$@"
-""" % (master_feed_name, release_uri, feed.local_path))
+""" % (release_uri, feed.local_path))
 		make_release.close()
 		os.chmod('make-release', 0775 & ~umask)
 		print "Success - created script:\n %s" % os.path.abspath('make-release')

--- a/support.py
+++ b/support.py
@@ -108,7 +108,7 @@ def show_diff(from_dir, to_dir):
 
 class Status(object):
 	__slots__ = ['old_snapshot_version', 'release_version', 'head_before_release', 'new_snapshot_version',
-		     'head_at_release', 'created_archive', 'src_tests_passed', 'tagged', 'verified_uploads']
+		     'head_at_release', 'created_archive', 'src_tests_passed', 'tagged']
 	def __init__(self):
 		for name in self.__slots__:
 			setattr(self, name, None)

--- a/tests/testall.py
+++ b/tests/testall.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 import unittest, os, sys
-try:
-	import coverage
-	coverage.use_cache(False)
-	coverage.erase()
-	coverage.start()
-except ImportError:
-	coverage = None
 
 my_dir = os.path.dirname(sys.argv[0])
 if not my_dir:
@@ -31,20 +24,6 @@ else:
 
 a = unittest.TextTestRunner(verbosity=2).run(alltests)
 
-if coverage:
-	coverage.stop()
-else:
-	print "Coverage module not found. Skipping coverage report."
-
 print "\nResult", a
 if not a.wasSuccessful():
 	sys.exit(1)
-
-if coverage:
-	all_sources = []
-	def incl(d):
-		for x in os.listdir(d):
-			if x.endswith('.py'):
-				all_sources.append(os.path.join(d, x))
-	incl('..')
-	coverage.report(all_sources + ['../0publish'])


### PR DESCRIPTION
0release displays a big warning if you try to use the old configuration, and has done since 2013. Remove support for that, and make it create new files in the modern configuration.

@bastianeicher I tried to make the same changes to the Windows code, but I didn't test it.